### PR TITLE
Add environment to Prometheus metrics

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,7 +4,7 @@ import { JSONResponse } from './utils/jsonResponse';
 export async function handleError(ctx: Context, error: Error) {
 	console.error(error.stack);
 
-	ctx.metrics.erroredRequestsTotal.inc();
+	ctx.metrics.erroredRequestsTotal.inc({ env: ctx.env.ENVIRONMENT });
 
 	const status = (error as HTTPError).status ?? 500;
 	const message = error.message || 'Server Error';

--- a/src/router.ts
+++ b/src/router.ts
@@ -107,7 +107,7 @@ export class Router {
 		ectx: ExecutionContext
 	): Promise<Response> {
 		const ctx = this.buildContext(request, env, ectx);
-		ctx.metrics.requestsTotal.inc();
+		ctx.metrics.requestsTotal.inc({ env: ctx.env.ENVIRONMENT });
 		const rawPath = new URL(request.url).pathname;
 		const path = this.normalisePath(rawPath);
 


### PR DESCRIPTION
Prometheus metrics should be sharded on environment to allow for a correct querying and identification down the line. This commit adds a dedicated `env` label to existing metrics.