### PR TITLE
Add key rotation support with multiple keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "pp-issuer",
 			"version": "0.1.0",
 			"dependencies": {
-				"@cloudflare/privacypass-ts": "^0.3.0",
+				"@cloudflare/privacypass-ts": "^0.4.0",
 				"@sentry/cli": "^2.18.1",
 				"@sentry/integrations": "^7.28.1",
 				"@sentry/types": "^7.28.1",
@@ -18,7 +18,7 @@
 			},
 			"devDependencies": {
 				"@cloudflare/blindrsa-ts": "^0.1.0",
-				"@cloudflare/workers-types": "4.20230518.0",
+				"@cloudflare/workers-types": "4.20231025.0",
 				"@types/jest": "29.5.2",
 				"dotenv": "16.1.3",
 				"esbuild": "0.17.19",
@@ -32,7 +32,7 @@
 				"prettier": "2.8.8",
 				"sade": "1.8.1",
 				"ts-jest": "29.1.0",
-				"wrangler": "3.1.1"
+				"wrangler": "3.15.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -661,9 +661,9 @@
 			}
 		},
 		"node_modules/@cloudflare/privacypass-ts": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/privacypass-ts/-/privacypass-ts-0.3.0.tgz",
-			"integrity": "sha512-pW3bcAEFiAqdew0+CUBZCSgiEbAq6UOZGfzoXSH9ZZ4ptGCQDIJlhdlfqD6jp98WIefJ74LzxmzIcCDrHS35zQ==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/privacypass-ts/-/privacypass-ts-0.4.0.tgz",
+			"integrity": "sha512-z4a6yxQb5fy8hpPBcScPe/InxppQY7omxzYXT8YIXpYDU0LU15N6I30isKMmaJ5zyLXU3liwPN6vEInxdA2oTg==",
 			"dependencies": {
 				"@cloudflare/blindrsa-ts": "0.1.0",
 				"asn1-parser": "1.1.8",
@@ -675,9 +675,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20230518.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230518.0.tgz",
-			"integrity": "sha512-reApIf2/do6GjLlajU6LbRYh8gm/XcaRtzGbF8jo5IzyDSsdStmfNuvq7qssZXG92219Yp1kuTgR9+D1GGZGbg==",
+			"version": "1.20231025.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20231025.0.tgz",
+			"integrity": "sha512-MYRYTbSl+tjGg6su7savlLIb8cOcKJfdGpA+WdtgqT2OF7O+89Lag0l1SA/iyVlUkT31Jc6OLHqvzsXgmg+niQ==",
 			"cpu": [
 				"x64"
 			],
@@ -691,9 +691,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20230518.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230518.0.tgz",
-			"integrity": "sha512-1l+xdbmPddqb2YIHd1YJ3YG/Fl1nhayzcxfL30xfNS89zJn9Xn3JomM0XMD4mk0d5GruBP3q8BQZ1Uo4rRLF3A==",
+			"version": "1.20231025.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20231025.0.tgz",
+			"integrity": "sha512-BszjtBDR84TVa6oWe74dePJSAukWlTmLw9zR4KeWuwZLJGV7RMm6AmwGStetjnwZrecZaaOFELfBCAHtsebV0Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -707,9 +707,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20230518.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230518.0.tgz",
-			"integrity": "sha512-/pfR+YBpMOPr2cAlwjtInil0hRZjD8KX9LqK9JkfkEiaBH8CYhnJQcOdNHZI+3OjcY09JnQtEVC5xC4nbW7Bvw==",
+			"version": "1.20231025.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20231025.0.tgz",
+			"integrity": "sha512-AT9dxgKXOa9xZxZ3k2a432axPJJ58KpoNWnPiPYGpuAuLoWnfcYwwh6mr9sZVcTdAdTAK9Xu9c81tp0YABanUw==",
 			"cpu": [
 				"x64"
 			],
@@ -723,9 +723,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20230518.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230518.0.tgz",
-			"integrity": "sha512-q3HQvn3J4uEkE0cfDAGG8zqzSZrD47cavB/Tzv4mNutqwg6B4wL3ifjtGeB55tnP2K2KL0GVmX4tObcvpUF4BA==",
+			"version": "1.20231025.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20231025.0.tgz",
+			"integrity": "sha512-EIjex5o2k80YZWPix1btGybL/vNZ3o6vqKX9ptS0JcFkHV5aFX5/kcMwSBRjiIC+w04zVjmGQx3N1Vh3njuncg==",
 			"cpu": [
 				"arm64"
 			],
@@ -739,9 +739,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20230518.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230518.0.tgz",
-			"integrity": "sha512-vNEHKS5gKKduNOBYtQjcBopAmFT1iScuPWMZa2nJboSjOB9I/5oiVsUpSyk5Y2ARyrohXNz0y8D7p87YzTASWw==",
+			"version": "1.20231025.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20231025.0.tgz",
+			"integrity": "sha512-7vtq0mO22A2v0OOsKXa760r9a84Gg8CK0gDu5uNWlj6hojmt011iz7jJt76I7oo/XrVwVlVfu69GnA3ljx6U8w==",
 			"cpu": [
 				"x64"
 			],
@@ -755,24 +755,24 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20230518.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20230518.0.tgz",
-			"integrity": "sha512-A0w1V+5SUawGaaPRlhFhSC/SCDT9oQG8TMoWOKFLA4qbqagELqEAFD4KySBIkeVOvCBLT1DZSYBMCxbXddl0kw==",
+			"version": "4.20231025.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20231025.0.tgz",
+			"integrity": "sha512-TkcZkntUTOcvJ4vgmwpNfLTclpMbmbClZCe62B25/VTukmyv91joRa4eKzSjzCZUXTbFHNmVdOpmGaaJU2U3+A==",
 			"dev": true
 		},
 		"node_modules/@esbuild-plugins/node-globals-polyfill": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.1.1.tgz",
-			"integrity": "sha512-MR0oAA+mlnJWrt1RQVQ+4VYuRJW/P2YmRTv1AsplObyvuBMnPHiizUF95HHYiSsMGLhyGtWufaq2XQg6+iurBg==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+			"integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
 			"dev": true,
 			"peerDependencies": {
 				"esbuild": "*"
 			}
 		},
 		"node_modules/@esbuild-plugins/node-modules-polyfill": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.1.4.tgz",
-			"integrity": "sha512-uZbcXi0zbmKC/050p3gJnne5Qdzw8vkXIv+c2BW0Lsc1ji1SkrxbKPUy5Efr0blbTu1SL8w4eyfpnSdPg3G0Qg==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+			"integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
 			"dev": true,
 			"dependencies": {
 				"escape-string-regexp": "^4.0.0",
@@ -1022,22 +1022,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/@esbuild/linux-x64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.3.tgz",
-			"integrity": "sha512-SDiG0nCixYO9JgpehoKgScwic7vXXndfasjnD5DLbp1xltANzqZ425l7LSdHynt19UWOcDjG9wJJzSElsPvk0w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/@esbuild/netbsd-x64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
@@ -1233,6 +1217,15 @@
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@fastify/busboy": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
+			"integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -1654,12 +1647,6 @@
 			"engines": {
 				"node": ">=16.13"
 			}
-		},
-		"node_modules/@miniflare/shared-test-environment/node_modules/@cloudflare/workers-types": {
-			"version": "4.20230419.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20230419.0.tgz",
-			"integrity": "sha512-MfNBlHrI/ekRkbLtdAo23D4hkXF+3QD92OCwuXxCUK73HtMHuBqkMp9T/8KFbKNRCnz7PzUderc7Jr5m3eeW3g==",
-			"dev": true
 		},
 		"node_modules/@miniflare/shared-test-environment/node_modules/@miniflare/cache": {
 			"version": "2.14.0",
@@ -2357,9 +2344,9 @@
 			}
 		},
 		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
+			"integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
@@ -2592,37 +2579,6 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
-		"node_modules/base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/better-sqlite3": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.4.0.tgz",
-			"integrity": "sha512-NmsNW1CQvqMszu/CFAJ3pLct6NEFlNfuGM6vw72KHkjOD1UDnL96XNN1BMQc1hiHo8vE2GbOWQYIpZ+YM5wrZw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"bindings": "^1.5.0",
-				"prebuild-install": "^7.1.0"
-			}
-		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -2630,26 +2586,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"dev": true,
-			"dependencies": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"node_modules/bl": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-			"dev": true,
-			"dependencies": {
-				"buffer": "^5.5.0",
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.4.0"
 			}
 		},
 		"node_modules/blake3-wasm": {
@@ -2729,30 +2665,6 @@
 				"node-int64": "^0.4.0"
 			}
 		},
-		"node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2829,9 +2741,9 @@
 			}
 		},
 		"node_modules/capnp-ts/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
 			"dev": true
 		},
 		"node_modules/chalk": {
@@ -2885,12 +2797,6 @@
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
 			}
-		},
-		"node_modules/chownr": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-			"dev": true
 		},
 		"node_modules/ci-info": {
 			"version": "3.8.0",
@@ -3034,35 +2940,11 @@
 				}
 			}
 		},
-		"node_modules/decompress-response": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-			"dev": true,
-			"dependencies": {
-				"mimic-response": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
 			"integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
 			"dev": true
-		},
-		"node_modules/deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0.0"
-			}
 		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
@@ -3077,15 +2959,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/detect-libc": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-			"integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/detect-newline": {
@@ -3178,15 +3051,6 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
-		},
-		"node_modules/end-of-stream": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"dev": true,
-			"dependencies": {
-				"once": "^1.4.0"
-			}
 		},
 		"node_modules/error-ex": {
 			"version": "1.3.2",
@@ -3646,15 +3510,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/expand-template": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/expect": {
 			"version": "29.5.0",
 			"resolved": "https://registry.npmjs.org/expect/-/expect-29.5.0.tgz",
@@ -3736,12 +3591,6 @@
 				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
-		"node_modules/file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true
-		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3784,12 +3633,6 @@
 			"version": "3.2.7",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-			"dev": true
-		},
-		"node_modules/fs-constants": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
 			"dev": true
 		},
 		"node_modules/fs.realpath": {
@@ -3855,15 +3698,6 @@
 				"source-map": "^0.6.1"
 			}
 		},
-		"node_modules/get-source/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/get-stream": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -3900,12 +3734,6 @@
 			"version": "4.1.15",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
 			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-			"dev": true
-		},
-		"node_modules/github-from-package": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
 			"dev": true
 		},
 		"node_modules/glob": {
@@ -4055,26 +3883,6 @@
 				"node": ">=12.20.0"
 			}
 		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
 		"node_modules/ignore": {
 			"version": "5.2.4",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -4156,12 +3964,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
-		},
-		"node_modules/ini": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true
 		},
 		"node_modules/interpret": {
@@ -4346,15 +4148,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/istanbul-reports": {
@@ -5753,17 +5546,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/jest-runner-eslint/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/jest-runner-eslint/node_modules/source-map-support": {
 			"version": "0.5.13",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
@@ -5800,15 +5582,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
-		"node_modules/jest-runner/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/jest-runner/node_modules/source-map-support": {
@@ -6234,42 +6007,39 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/mimic-response": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/miniflare": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.1.tgz",
-			"integrity": "sha512-aLOB8d26lOTn493GOv1LmpGHVLSxmeT4MixPG/k3Ze10j0wDKnMj8wsFgbZ6Q4cr1N4faf8O3IbNRJuQ+rLoJA==",
+			"version": "3.20231025.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20231025.0.tgz",
+			"integrity": "sha512-pFcr2BRaGIQ26UfdDo8BMJ6kkd/Jo/FkQ/4K7UG/eORlDepsLrR/sTJddcSSIGl07MA+MGjhzopFTPpFskkS+g==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^8.1.0",
 				"capnp-ts": "^0.7.0",
 				"exit-hook": "^2.2.1",
 				"glob-to-regexp": "^0.4.1",
-				"http-cache-semantics": "^4.1.0",
-				"kleur": "^4.1.5",
 				"source-map-support": "0.5.21",
 				"stoppable": "^1.1.0",
-				"undici": "^5.13.0",
-				"workerd": "^1.20230512.0",
+				"undici": "^5.22.1",
+				"workerd": "1.20231025.0",
 				"ws": "^8.11.0",
 				"youch": "^3.2.2",
 				"zod": "^3.20.6"
 			},
 			"engines": {
 				"node": ">=16.13"
+			}
+		},
+		"node_modules/miniflare/node_modules/undici": {
+			"version": "5.27.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.27.0.tgz",
+			"integrity": "sha512-l3ydWhlhOJzMVOYkymLykcRRXqbUaQriERtR70B9LzNkZ4bX52Fc8wbTDneMiwo8T+AemZXvXaTx+9o5ROxrXg==",
+			"dev": true,
+			"dependencies": {
+				"@fastify/busboy": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.0"
 			}
 		},
 		"node_modules/minimatch": {
@@ -6283,21 +6053,6 @@
 			"engines": {
 				"node": "*"
 			}
-		},
-		"node_modules/minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/mkdirp-classic": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-			"dev": true
 		},
 		"node_modules/mri": {
 			"version": "1.2.0",
@@ -6340,12 +6095,6 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
-		"node_modules/napi-build-utils": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-			"dev": true
-		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6358,18 +6107,6 @@
 			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/node-abi": {
-			"version": "3.43.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.43.0.tgz",
-			"integrity": "sha512-QB0MMv+tn9Ur2DtJrc8y09n0n6sw88CyDniWSX2cHW10goQXYPK9ZpFJOktDS4ron501edPX6h9i7Pg+RnH5nQ==",
-			"dev": true,
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/node-fetch": {
 			"version": "2.6.11",
@@ -6674,32 +6411,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/prebuild-install": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-			"integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
-			"dev": true,
-			"dependencies": {
-				"detect-libc": "^2.0.0",
-				"expand-template": "^2.0.3",
-				"github-from-package": "0.0.0",
-				"minimist": "^1.2.3",
-				"mkdirp-classic": "^0.5.3",
-				"napi-build-utils": "^1.0.1",
-				"node-abi": "^3.3.0",
-				"pump": "^3.0.0",
-				"rc": "^1.2.7",
-				"simple-get": "^4.0.0",
-				"tar-fs": "^2.0.0",
-				"tunnel-agent": "^0.6.0"
-			},
-			"bin": {
-				"prebuild-install": "bin.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6796,16 +6507,6 @@
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
 		},
-		"node_modules/pump": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-			"dev": true,
-			"dependencies": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
-			}
-		},
 		"node_modules/punycode": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -6872,49 +6573,11 @@
 				}
 			]
 		},
-		"node_modules/rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"dev": true,
-			"dependencies": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"bin": {
-				"rc": "cli.js"
-			}
-		},
-		"node_modules/rc/node_modules/strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/react-is": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 			"dev": true
-		},
-		"node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
 		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
@@ -7091,26 +6754,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
 		"node_modules/selfsigned": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.1.1.tgz",
@@ -7188,51 +6831,6 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
 		},
-		"node_modules/simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/simple-get": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"decompress-response": "^6.0.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
-		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7257,12 +6855,12 @@
 			}
 		},
 		"node_modules/source-map": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true,
 			"engines": {
-				"node": ">= 8"
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/source-map-support": {
@@ -7273,15 +6871,6 @@
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
-			}
-		},
-		"node_modules/source-map-support/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/sourcemap-codec": {
@@ -7345,15 +6934,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/string-length": {
@@ -7450,34 +7030,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/tar-fs": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-			"dev": true,
-			"dependencies": {
-				"chownr": "^1.1.1",
-				"mkdirp-classic": "^0.5.2",
-				"pump": "^3.0.0",
-				"tar-stream": "^2.1.4"
-			}
-		},
-		"node_modules/tar-stream": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-			"dev": true,
-			"dependencies": {
-				"bl": "^4.0.3",
-				"end-of-stream": "^1.4.1",
-				"fs-constants": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1"
-			},
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/test-exclude": {
@@ -7612,18 +7164,6 @@
 				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
 			}
 		},
-		"node_modules/tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7726,12 +7266,6 @@
 			"integrity": "sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ==",
 			"dev": true
 		},
-		"node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
-		},
 		"node_modules/v8-to-istanbul": {
 			"version": "9.1.0",
 			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -7811,9 +7345,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20230518.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230518.0.tgz",
-			"integrity": "sha512-VNmK0zoNZXrwEEx77O/oQDVUzzyDjf5kKKK8bty+FmKCd5EQJCpqi8NlRKWLGMyyYrKm86MFz0kAsreTEs7HHA==",
+			"version": "1.20231025.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20231025.0.tgz",
+			"integrity": "sha512-W1PFtpMFfvmm+ozBf+u70TE3Pviv7WA4qzDeejHDC4z+PFDq4+3KJCkgffaGBO86h+akWO0hSsc0uXL2zAqofQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -7823,30 +7357,32 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20230518.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20230518.0",
-				"@cloudflare/workerd-linux-64": "1.20230518.0",
-				"@cloudflare/workerd-linux-arm64": "1.20230518.0",
-				"@cloudflare/workerd-windows-64": "1.20230518.0"
+				"@cloudflare/workerd-darwin-64": "1.20231025.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20231025.0",
+				"@cloudflare/workerd-linux-64": "1.20231025.0",
+				"@cloudflare/workerd-linux-arm64": "1.20231025.0",
+				"@cloudflare/workerd-windows-64": "1.20231025.0"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.1.1.tgz",
-			"integrity": "sha512-iG6QGOt+qgSm7UroJ8IJ+JdXEcDcW7yp9ilP0V7alCGhKm8shqa/M1iyMOpukZSCSZo8Vmn5nH2C9OY1PR3dQQ==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.15.0.tgz",
+			"integrity": "sha512-kxzK62rD+LRrDeZZzw8cP6FBub71vJCbfAAb594XobXajgXYh3pFjv18Vm8YLxHzoGMhmAOJPA5b4DHq4HEUCw==",
 			"dev": true,
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "^0.2.0",
-				"@esbuild-plugins/node-globals-polyfill": "^0.1.1",
-				"@esbuild-plugins/node-modules-polyfill": "^0.1.4",
+				"@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+				"@esbuild-plugins/node-modules-polyfill": "^0.2.2",
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
-				"esbuild": "0.16.3",
-				"miniflare": "^3.0.1",
+				"esbuild": "0.17.19",
+				"miniflare": "3.20231025.0",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
+				"resolve.exports": "^2.0.2",
 				"selfsigned": "^2.0.1",
-				"source-map": "^0.7.4",
+				"source-map": "0.6.1",
+				"source-map-support": "0.5.21",
 				"xxhash-wasm": "^1.0.1"
 			},
 			"bin": {
@@ -7854,383 +7390,10 @@
 				"wrangler2": "bin/wrangler.js"
 			},
 			"engines": {
-				"node": ">=16.13.0"
+				"node": ">=16.17.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/android-arm": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.3.tgz",
-			"integrity": "sha512-mueuEoh+s1eRbSJqq9KNBQwI4QhQV6sRXIfTyLXSHGMpyew61rOK4qY21uKbXl1iBoMb0AdL1deWFCQVlN2qHA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/android-arm64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.3.tgz",
-			"integrity": "sha512-RolFVeinkeraDvN/OoRf1F/lP0KUfGNb5jxy/vkIMeRRChkrX/HTYN6TYZosRJs3a1+8wqpxAo5PI5hFmxyPRg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/android-x64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.3.tgz",
-			"integrity": "sha512-SFpTUcIT1bIJuCCBMCQWq1bL2gPTjWoLZdjmIhjdcQHaUfV41OQfho6Ici5uvvkMmZRXIUGpM3GxysP/EU7ifQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.3.tgz",
-			"integrity": "sha512-DO8WykMyB+N9mIDfI/Hug70Dk1KipavlGAecxS3jDUwAbTpDXj0Lcwzw9svkhxfpCagDmpaTMgxWK8/C/XcXvw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.3.tgz",
-			"integrity": "sha512-uEqZQ2omc6BvWqdCiyZ5+XmxuHEi1SPzpVxXCSSV2+Sh7sbXbpeNhHIeFrIpRjAs0lI1FmA1iIOxFozKBhKgRQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.3.tgz",
-			"integrity": "sha512-nJansp3sSXakNkOD5i5mIz2Is/HjzIhFs49b1tjrPrpCmwgBmH9SSzhC/Z1UqlkivqMYkhfPwMw1dGFUuwmXhw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.3.tgz",
-			"integrity": "sha512-TfoDzLw+QHfc4a8aKtGSQ96Wa+6eimljjkq9HKR0rHlU83vw8aldMOUSJTUDxbcUdcgnJzPaX8/vGWm7vyV7ug==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-arm": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.3.tgz",
-			"integrity": "sha512-VwswmSYwVAAq6LysV59Fyqk3UIjbhuc6wb3vEcJ7HEJUtFuLK9uXWuFoH1lulEbE4+5GjtHi3MHX+w1gNHdOWQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.3.tgz",
-			"integrity": "sha512-7I3RlsnxEFCHVZNBLb2w7unamgZ5sVwO0/ikE2GaYvYuUQs9Qte/w7TqWcXHtCwxvZx/2+F97ndiUQAWs47ZfQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.3.tgz",
-			"integrity": "sha512-X8FDDxM9cqda2rJE+iblQhIMYY49LfvW4kaEjoFbTTQ4Go8G96Smj2w3BRTwA8IHGoi9dPOPGAX63dhuv19UqA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.3.tgz",
-			"integrity": "sha512-hIbeejCOyO0X9ujfIIOKjBjNAs9XD/YdJ9JXAy1lHA+8UXuOqbFe4ErMCqMr8dhlMGBuvcQYGF7+kO7waj2KHw==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.3.tgz",
-			"integrity": "sha512-znFRzICT/V8VZQMt6rjb21MtAVJv/3dmKRMlohlShrbVXdBuOdDrGb+C2cZGQAR8RFyRe7HS6klmHq103WpmVw==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.3.tgz",
-			"integrity": "sha512-EV7LuEybxhXrVTDpbqWF2yehYRNz5e5p+u3oQUS2+ZFpknyi1NXxr8URk4ykR8Efm7iu04//4sBg249yNOwy5Q==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.3.tgz",
-			"integrity": "sha512-uDxqFOcLzFIJ+r/pkTTSE9lsCEaV/Y6rMlQjUI9BkzASEChYL/aSQjZjchtEmdnVxDKETnUAmsaZ4pqK1eE5BQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.3.tgz",
-			"integrity": "sha512-NbeREhzSxYwFhnCAQOQZmajsPYtX71Ufej3IQ8W2Gxskfz9DK58ENEju4SbpIj48VenktRASC52N5Fhyf/aliQ==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.3.tgz",
-			"integrity": "sha512-AzbsJqiHEq1I/tUvOfAzCY15h4/7Ivp3ff/o1GpP16n48JMNAtbW0qui2WCgoIZArEHD0SUQ95gvR0oSO7ZbdA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.3.tgz",
-			"integrity": "sha512-gSABi8qHl8k3Cbi/4toAzHiykuBuWLZs43JomTcXkjMZVkp0gj3gg9mO+9HJW/8GB5H89RX/V0QP4JGL7YEEVg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.3.tgz",
-			"integrity": "sha512-SF9Kch5Ete4reovvRO6yNjMxrvlfT0F0Flm+NPoUw5Z4Q3r1d23LFTgaLwm3Cp0iGbrU/MoUI+ZqwCv5XJijCw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.3.tgz",
-			"integrity": "sha512-u5aBonZIyGopAZyOnoPAA6fGsDeHByZ9CnEzyML9NqntK6D/xl5jteZUKm/p6nD09+v3pTM6TuUIqSPcChk5gg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.3.tgz",
-			"integrity": "sha512-GlgVq1WpvOEhNioh74TKelwla9KDuAaLZrdxuuUgsP2vayxeLgVc+rbpIv0IYF4+tlIzq2vRhofV+KGLD+37EQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/win32-x64": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.3.tgz",
-			"integrity": "sha512-5/JuTd8OWW8UzEtyf19fbrtMJENza+C9JoPIkvItgTBQ1FO2ZLvjbPO6Xs54vk0s5JB5QsfieUEshRQfu7ZHow==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/wrangler/node_modules/esbuild": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.3.tgz",
-			"integrity": "sha512-71f7EjPWTiSguen8X/kxEpkAS7BFHwtQKisCDDV3Y4GLGWBaoSCyD5uXkaUew6JDzA9FEN1W23mdnSwW9kqCeg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"optionalDependencies": {
-				"@esbuild/android-arm": "0.16.3",
-				"@esbuild/android-arm64": "0.16.3",
-				"@esbuild/android-x64": "0.16.3",
-				"@esbuild/darwin-arm64": "0.16.3",
-				"@esbuild/darwin-x64": "0.16.3",
-				"@esbuild/freebsd-arm64": "0.16.3",
-				"@esbuild/freebsd-x64": "0.16.3",
-				"@esbuild/linux-arm": "0.16.3",
-				"@esbuild/linux-arm64": "0.16.3",
-				"@esbuild/linux-ia32": "0.16.3",
-				"@esbuild/linux-loong64": "0.16.3",
-				"@esbuild/linux-mips64el": "0.16.3",
-				"@esbuild/linux-ppc64": "0.16.3",
-				"@esbuild/linux-riscv64": "0.16.3",
-				"@esbuild/linux-s390x": "0.16.3",
-				"@esbuild/linux-x64": "0.16.3",
-				"@esbuild/netbsd-x64": "0.16.3",
-				"@esbuild/openbsd-x64": "0.16.3",
-				"@esbuild/sunos-x64": "0.16.3",
-				"@esbuild/win32-arm64": "0.16.3",
-				"@esbuild/win32-ia32": "0.16.3",
-				"@esbuild/win32-x64": "0.16.3"
 			}
 		},
 		"node_modules/wrap-ansi": {
@@ -8360,9 +7523,9 @@
 			}
 		},
 		"node_modules/youch": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
-			"integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/youch/-/youch-3.3.2.tgz",
+			"integrity": "sha512-9cwz/z7abtcHOIuH45nzmUFCZbyJA1nLqlirKvyNRx4wDMhqsBaifAJzBej7L4fsVPjFxYq3NK3GAcfvZsydFw==",
 			"dev": true,
 			"dependencies": {
 				"cookie": "^0.5.0",
@@ -8371,9 +7534,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.21.4",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-			"integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+			"version": "3.22.4",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+			"integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"build": "tsc && node scripts/cli.js build",
 		"deploy:production": "wrangler deploy --no-bundle --env production",
-		"dev": "wrangler dev --env production --local",
+		"dev": "wrangler dev --env production --test-scheduled",
 		"format": "prettier --write  '*.{json,js}' 'src/**/*.{js,ts}' 'test/**/*.{js,ts}'",
 		"lint": "eslint src && prettier --check '*.{json,js}' 'src/**/*.{js,ts}' 'test/**/*.{js,ts}'",
 		"test": "npm run build && node --experimental-vm-modules --no-warnings node_modules/.bin/jest"
@@ -21,7 +21,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/blindrsa-ts": "^0.1.0",
-		"@cloudflare/workers-types": "4.20230518.0",
+		"@cloudflare/workers-types": "4.20231025.0",
 		"@types/jest": "29.5.2",
 		"dotenv": "16.1.3",
 		"esbuild": "0.17.19",
@@ -35,10 +35,10 @@
 		"prettier": "2.8.8",
 		"sade": "1.8.1",
 		"ts-jest": "29.1.0",
-		"wrangler": "3.1.1"
+		"wrangler": "3.15.0"
 	},
 	"dependencies": {
-		"@cloudflare/privacypass-ts": "^0.3.0",
+		"@cloudflare/privacypass-ts": "^0.4.0",
 		"@sentry/cli": "^2.18.1",
 		"@sentry/integrations": "^7.28.1",
 		"@sentry/types": "^7.28.1",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1,3 +1,5 @@
+import type { R2Bucket } from '@cloudflare/workers-types/2023-07-01';
+
 export interface Bindings {
 	// variables and secrets
 	ENVIRONMENT: string;

--- a/src/context/metrics.ts
+++ b/src/context/metrics.ts
@@ -15,6 +15,8 @@ export class MetricsRegistry {
 
 	requestsTotal: CounterType;
 	erroredRequestsTotal: CounterType;
+	keyRotationTotal: CounterType;
+	keyClearTotal: CounterType;
 
 	constructor(options: RegistryOptions) {
 		this.options = options;
@@ -25,6 +27,16 @@ export class MetricsRegistry {
 			'counter',
 			'errored_requests_total',
 			'Errored requests served to eyeball'
+		);
+		this.keyRotationTotal = this.registry.create(
+			'counter',
+			'key_rotation_total',
+			'Number of key rotation performed.'
+		);
+		this.keyClearTotal = this.registry.create(
+			'counter',
+			'key_clear_total',
+			'Number of key clear performed.'
 		);
 	}
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,11 +1,23 @@
 import { Context } from '../src/context';
 import { handleTokenRequest, default as workerObject } from '../src/index';
+import { IssuerConfigurationResponse } from '../src/types';
 import { b64ToB64URL, u8ToB64 } from '../src/utils/base64';
 import { ExecutionContextMock, getContext, getEnv } from './mocks';
 import * as blindrsa from '@cloudflare/blindrsa-ts';
-import { TokenRequest, util } from '@cloudflare/privacypass-ts';
+import {
+	MediaType,
+	PRIVATE_TOKEN_ISSUER_DIRECTORY,
+	TokenRequest,
+	util,
+} from '@cloudflare/privacypass-ts';
 
 const sampleURL = 'http://localhost';
+
+const keyToTokenKeyID = async (key: Uint8Array): Promise<number> => {
+	const hash = await crypto.subtle.digest('SHA-256', key);
+	const u8 = new Uint8Array(hash);
+	return u8[u8.length - 1];
+};
 
 describe('challenge handlers', () => {
 	const suite = blindrsa.SUITES.SHA384.PSS.Deterministic();
@@ -24,8 +36,9 @@ describe('challenge handlers', () => {
 			(await crypto.subtle.exportKey('spki', keypair.publicKey)) as ArrayBuffer
 		);
 		const publicKeyEnc = b64ToB64URL(u8ToB64(util.convertEncToRSASSAPSS(publicKey)));
+		const tokenKey = await keyToTokenKeyID(new TextEncoder().encode(publicKeyEnc));
 		await ctx.env.ISSUANCE_KEYS.put(
-			'latest',
+			tokenKey.toString(),
 			(await crypto.subtle.exportKey('pkcs8', keypair.privateKey)) as ArrayBuffer,
 			{ customMetadata: { publicKey: publicKeyEnc } }
 		);
@@ -45,24 +58,21 @@ describe('challenge handlers', () => {
 		);
 		const publicKeyU8 = util.convertEncToRSASSAPSS(publicKeyExport);
 		const publicKeyEnc = b64ToB64URL(u8ToB64(publicKeyU8));
-		const keyId = new Uint8Array(
-			await crypto.subtle.digest('SHA-256', new TextEncoder().encode(publicKeyEnc))
-		);
-		const tokenKeyId = keyId[keyId.length - 1];
+		const tokenKeyId = await keyToTokenKeyID(new TextEncoder().encode(publicKeyEnc));
 
 		// note that blindedMsg should be the payload and not the message directly
 		const tokenRequest = new TokenRequest(tokenKeyId, blindedMsg);
 
 		const request = new Request(tokenRequestURL, {
 			method: 'POST',
-			headers: { 'content-type': 'application/private-token-request' },
+			headers: { 'content-type': MediaType.PRIVATE_TOKEN_REQUEST },
 			body: tokenRequest.serialize(),
 		});
 
 		const response = await handleTokenRequest(ctx, request);
 
 		expect(response.status).toBe(200);
-		expect(response.headers.get('content-type')).toBe('application/private-token-response');
+		expect(response.headers.get('content-type')).toBe(MediaType.PRIVATE_TOKEN_RESPONSE);
 
 		const blindSignature = new Uint8Array(await response.arrayBuffer());
 		const signature = await suite.finalize(publicKey, preparedMsg, blindSignature, inv);
@@ -86,5 +96,53 @@ describe('non existing handler', () => {
 		const response = await workerObject.fetch(request, getEnv(), new ExecutionContextMock());
 
 		expect(response.status).toBe(404);
+	});
+});
+
+describe('rotate and clear key', () => {
+	const rotateURL = `${sampleURL}/admin/rotate`;
+	const clearURL = `${sampleURL}/admin/clear`;
+	const directoryURL = `${sampleURL}${PRIVATE_TOKEN_ISSUER_DIRECTORY}`;
+
+	it('should generate multiple keys', async () => {
+		const rotateRequest = new Request(rotateURL, { method: 'POST' });
+		const directoryRequest = new Request(directoryURL);
+
+		const NUMBER_OF_KEYS_GENERATED = 3;
+		for (let i = 0; i < NUMBER_OF_KEYS_GENERATED; i += 1) {
+			await workerObject.fetch(rotateRequest, getEnv(), new ExecutionContextMock());
+		}
+
+		const response = await workerObject.fetch(
+			directoryRequest,
+			getEnv(),
+			new ExecutionContextMock()
+		);
+		expect(response.ok).toBe(true);
+
+		const directory: IssuerConfigurationResponse = await response.json();
+		expect(directory['token-keys']).toHaveLength(NUMBER_OF_KEYS_GENERATED);
+	});
+
+	it('should clear keys and keep only one', async () => {
+		const rotateRequest = new Request(rotateURL, { method: 'POST' });
+		const clearRequest = new Request(clearURL, { method: 'POST' });
+		const directoryRequest = new Request(directoryURL);
+
+		const NUMBER_OF_KEYS_GENERATED = 3;
+		for (let i = 0; i < NUMBER_OF_KEYS_GENERATED; i += 1) {
+			await workerObject.fetch(rotateRequest, getEnv(), new ExecutionContextMock());
+		}
+		await workerObject.fetch(clearRequest, getEnv(), new ExecutionContextMock());
+
+		const response = await workerObject.fetch(
+			directoryRequest,
+			getEnv(),
+			new ExecutionContextMock()
+		);
+		expect(response.ok).toBe(true);
+
+		const directory: IssuerConfigurationResponse = await response.json();
+		expect(directory['token-keys']).toHaveLength(1);
 	});
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,4 +16,5 @@ SENTRY_SAMPLE_RATE = "0" # Between 0-1 if you log errors on Sentry. 0 disables S
 
 [[env.production.r2_buckets]]
 bucket_name = 'pp-issuer-keys-production' # wrangler r2 bucket create pp-issuer-keys-production. Pricing and free tier described on https://developers.cloudflare.com/r2/pricing
+preview_bucket_name = 'pp-issuer-keys-production-local'
 binding = 'ISSUANCE_KEYS'


### PR DESCRIPTION
Issuer key can be rotated to minimise attack surface. This implies that two keys might live at the same time, and that keys might have to be cleaned after some time.

This commit adds support for keuy rotation. It does so by adding a daily cron trigger. On the first of the month, a new key is added. Every day which is not the first, keys are cleared so only the latest one persists.
A new admin endpoint is also included /admin/clear to manually trigger the clearing of keys.

Finally, the test suite is updated to reflect the underlying change in key indexation, which now rely on truncated token id.

You can test locally with `npm run dev`