### PR TITLE
Add metrics on issuance errors

### DIFF
--- a/src/context/metrics.ts
+++ b/src/context/metrics.ts
@@ -3,6 +3,13 @@ import { Registry } from 'promjs/registry';
 import { Bindings } from '../bindings';
 export const METRICS_ENDPOINT = 'https://workers-logging.cfdata.org/prometheus';
 
+export const KeyError = {
+	NOT_FOUND: 'not-found',
+	INVALID_PRIVATE_KEY: 'invalid-private-key',
+	MISSING_PRIVATE_KEY: 'missing-private-key',
+	MISSING_PUBLIC_KEY: 'missing-public-key',
+};
+
 export interface RegistryOptions {
 	bearerToken?: string;
 }
@@ -23,6 +30,7 @@ export class MetricsRegistry {
 
 	directoryCacheMissTotal: CounterType;
 	erroredRequestsTotal: CounterType;
+	issuanceKeyErrorTotal: CounterType;
 	issuanceRequestTotal: CounterType;
 	keyRotationTotal: CounterType;
 	keyClearTotal: CounterType;
@@ -44,6 +52,11 @@ export class MetricsRegistry {
 			'counter',
 			'errored_requests_total',
 			'Errored requests served to eyeball'
+		);
+		this.issuanceKeyErrorTotal = this.create(
+			'counter',
+			'issuance_key_error_total',
+			'Number of key errors encountered when issuing a private token.'
 		);
 		this.issuanceRequestTotal = this.create(
 			'counter',


### PR DESCRIPTION
Provide the requested key id, as well as a reason for failing.