### PR TITLE
Add duration metrics

### DIFF
--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1,4 +1,4 @@
-import type { R2Bucket } from '@cloudflare/workers-types/2023-07-01';
+import type { R2Bucket, Performance } from '@cloudflare/workers-types/2023-07-01';
 
 export interface Bindings {
 	// variables and secrets
@@ -13,4 +13,7 @@ export interface Bindings {
 
 	// R2 buckets
 	ISSUANCE_KEYS: R2Bucket;
+
+	// Performance Timer
+	PERFORMANCE: Performance | undefined;
 }

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -6,8 +6,10 @@ import { MetricsRegistry } from './metrics';
 export type WaitUntilFunc = (p: Promise<unknown>) => void;
 
 export class Context {
+	public startTime: number;
 	private promises: Promise<unknown>[] = [];
 	public cache: { ISSUANCE_KEYS: CachedR2Bucket };
+	public performance: Performance;
 
 	constructor(
 		public env: Bindings,
@@ -19,6 +21,9 @@ export class Context {
 		this.cache = {
 			ISSUANCE_KEYS: new CachedR2Bucket(this, env.ISSUANCE_KEYS, cache),
 		};
+
+		this.performance = env.PERFORMANCE ?? self.performance;
+		this.startTime = this.performance.now();
 	}
 
 	isTest(): boolean {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,4 @@
+import { Labels } from 'promjs';
 import { Context } from './context';
 import { JSONResponse } from './utils/jsonResponse';
 
@@ -8,10 +9,10 @@ function shouldSendToSentry(error: Error): boolean {
 	return true;
 }
 
-export async function handleError(ctx: Context, error: Error) {
+export async function handleError(ctx: Context, error: Error, labels?: Labels) {
 	console.error(error.stack);
 
-	ctx.metrics.erroredRequestsTotal.inc();
+	ctx.metrics.erroredRequestsTotal.inc(labels);
 
 	const status = (error as HTTPError).status ?? 500;
 	const message = error.message || 'Server Error';


### PR DESCRIPTION
Record time it takes for the API to respond.
In addition, record the path associated to certain metrics. This should facilitate debugging.

All tests are passing.