### PR TITLE
Add version metadata binding

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,7 @@ export default {
 			testEnvironmentOptions: {
 				bindings: {
 					LOGGING_SHIM_TOKEN: '',
+					VERSION_METADATA: '',
 				},
 				wranglerConfigEnv: 'production',
 			},

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -16,4 +16,7 @@ export interface Bindings {
 
 	// Performance Timer
 	PERFORMANCE: Performance | undefined;
+
+	// Worker version metadata
+	VERSION_METADATA: ScriptVersion;
 }

--- a/src/context/metrics.ts
+++ b/src/context/metrics.ts
@@ -17,6 +17,7 @@ export interface RegistryOptions {
 export interface DefaultLabels {
 	env: string;
 	service: string;
+	version: string;
 }
 
 const HISTOGRAM_MS_BUCKETS = [50, 100, 200, 400, 1000, 2 * 1000, 4 * 1000];
@@ -91,9 +92,17 @@ export class MetricsRegistry {
 		this.r2RequestsTotal = this.create('counter', 'r2_requests_total', 'Number of accesses to R2');
 	}
 
+	private defaultLabels(): DefaultLabels {
+		return {
+			env: this.env.ENVIRONMENT,
+			service: this.env.SERVICE,
+			version: this.env.VERSION_METADATA.id ?? RELEASE,
+		};
+	}
+
 	private createCounter(name: string, help?: string): CounterType {
 		const counter = this.registry.create('counter', name, help);
-		const defaultLabels: DefaultLabels = { env: this.env.ENVIRONMENT, service: this.env.SERVICE };
+		const defaultLabels = this.defaultLabels();
 		return new Proxy(counter, {
 			get(target, prop, receiver) {
 				if (['collect', 'get', 'inc', 'reset'].includes(prop.toString())) {
@@ -115,7 +124,7 @@ export class MetricsRegistry {
 
 	private createHistogram(name: string, help?: string, histogramBuckets?: number[]): HistogramType {
 		const histogram = this.registry.create('histogram', name, help, histogramBuckets);
-		const defaultLabels: DefaultLabels = { env: this.env.ENVIRONMENT, service: this.env.SERVICE };
+		const defaultLabels = this.defaultLabels();
 		return new Proxy(histogram, {
 			get(target, prop, receiver) {
 				if (['collect', 'get', 'reset'].includes(prop.toString())) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,3 +23,6 @@ SERVICE = "pp-issuer-production"
 bucket_name = 'pp-issuer-keys-production' # wrangler r2 bucket create pp-issuer-keys-production. Pricing and free tier described on https://developers.cloudflare.com/r2/pricing
 preview_bucket_name = 'pp-issuer-keys-production-local'
 binding = 'ISSUANCE_KEYS'
+
+[env.production.version_metadata]
+binding = "VERSION_METADATA"


### PR DESCRIPTION
Exposes [version metadata](https://developers.cloudflare.com/workers/runtime-apis/bindings/version-metadata/) to the worker. It also adds the version ID to the default label set, allowing to track metrics across versions.