### PR TITLE
Add metrics cache and r2

### DIFF
--- a/src/context/metrics.ts
+++ b/src/context/metrics.ts
@@ -43,7 +43,7 @@ export class MetricsRegistry {
 	requestsDurationMs: HistogramType;
 	requestsTotal: CounterType;
 	signedTokenTotal: CounterType;
-	r2RequestsTotal: CounterType;
+	r2RequestsDurationMs: HistogramType;
 
 	constructor(env: Bindings, options: RegistryOptions) {
 		this.env = env;
@@ -92,7 +92,12 @@ export class MetricsRegistry {
 			'signed_token_total',
 			'Number of issued signed private tokens.'
 		);
-		this.r2RequestsTotal = this.create('counter', 'r2_requests_total', 'Number of accesses to R2');
+		this.r2RequestsDurationMs = this.create(
+			'histogram',
+			'r2_requests_duration_ms',
+			'R2 request duration',
+			HISTOGRAM_MS_BUCKETS
+		);
 	}
 
 	private defaultLabels(): DefaultLabels {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -74,6 +74,17 @@ export class HeaderNotDefinedError extends HTTPError {
 	}
 }
 
+export class InternalCacheError extends HTTPError {
+	static CODE = 'ERROR_INTERNAL_CACHE_ERROR';
+	code: string;
+
+	constructor(message = 'Internal cache error') {
+		super(message, 500);
+		this.name = 'InternalCacheError';
+		this.code = InternalCacheError.CODE;
+	}
+}
+
 export class NotImplementedError extends HTTPError {
 	static CODE = 'ERROR_NOT_IMPLEMENTED';
 	code: string;


### PR DESCRIPTION
Better handle error on cache connection failure.
Add monitoring for the duration of R2 calls.

Both these changes should provide additional visibility into some environmental failures.