### PR TITLE
feat: add status code and isHTTPError function

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -12,6 +12,10 @@ function shouldSendToSentry(error: Error): boolean {
 	return true;
 }
 
+export function isHTTPError(error: unknown): error is HTTPError {
+	return error instanceof HTTPError;
+}
+
 export async function handleError(ctx: Context, error: Error, labels?: Labels) {
 	console.error(error.stack);
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,7 +6,7 @@ import { Bindings } from './bindings';
 import { Context } from './context';
 import { ConsoleLogger, FlexibleLogger, Logger } from './context/logging';
 import { MetricsRegistry } from './context/metrics';
-import { MethodNotAllowedError, PageNotFoundError, handleError } from './errors';
+import { MethodNotAllowedError, PageNotFoundError, handleError, isHTTPError } from './errors';
 
 const HttpMethod = {
 	DELETE: 'DELETE',
@@ -154,6 +154,9 @@ export class Router {
 			}
 			response = await handlers[path](ctx, request);
 		} catch (e: unknown) {
+			if (isHTTPError(e)) {
+				response = await handleError(ctx, e as Error, { path, status: e.status });
+			}
 			response = await handleError(ctx, e as Error, { path });
 		}
 		ctx.metrics.requestsDurationMs.observe(ctx.performance.now() - ctx.startTime, { path });


### PR DESCRIPTION
- Added a status code to the handleError call to provide more detailed error information.
- Implemented the isHTTPError function to properly type-check errors caught in the catch block.
- This ensures that HTTP errors are correctly identified and handled, improving error reporting and debugging.