### PR TITLE
Ignore HeaderNotDefinedError for Sentry

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,7 +6,11 @@ import { Context } from './context';
 import { JSONResponse } from './utils/jsonResponse';
 
 function shouldSendToSentry(error: Error): boolean {
-	if (error instanceof PageNotFoundError || error instanceof MethodNotAllowedError) {
+	if (
+		error instanceof PageNotFoundError ||
+		error instanceof MethodNotAllowedError ||
+		error instanceof HeaderNotDefinedError
+	) {
 		return false;
 	}
 	return true;


### PR DESCRIPTION
This is a noisy error. Metrics around it are sufficient. It should not be sent to sentry.