### PR TITLE
Fix HTTP status for bad token id

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -121,3 +121,14 @@ export class InvalidTokenTypeError extends HTTPError {
 		this.code = InvalidTokenTypeError.CODE;
 	}
 }
+
+export class BadTokenKeyRequestedError extends HTTPError {
+	static CODE = 'ERROR_BAD_TOKEN_KEY_REQUESTED';
+	code: string;
+
+	constructor(message = 'Bad token key requested') {
+		super(message, 400);
+		this.name = 'BadTokenKeyRequestedError';
+		this.code = BadTokenKeyRequestedError.CODE;
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,12 @@
 import { Bindings } from './bindings';
 import { Context } from './context';
 import { Router } from './router';
-import { HeaderNotDefinedError, InternalCacheError, InvalidTokenTypeError } from './errors';
+import {
+	BadTokenKeyRequestedError,
+	HeaderNotDefinedError,
+	InternalCacheError,
+	InvalidTokenTypeError,
+} from './errors';
 import { IssuerConfigurationResponse, TokenType } from './types';
 import { b64ToB64URL, b64Tou8, b64URLtoB64, u8ToB64 } from './utils/base64';
 import {
@@ -54,7 +59,7 @@ export const handleTokenRequest = async (ctx: Context, request: Request) => {
 
 	if (key === null) {
 		ctx.metrics.issuanceKeyErrorTotal.inc({ key_id: keyID, type: KeyError.NOT_FOUND });
-		throw new Error('No key found for the requested key id');
+		throw new BadTokenKeyRequestedError('No key found for the requested key id');
 	}
 
 	const privateKey = key.data;


### PR DESCRIPTION
A bad token id is a bad request, which is HTTP 400, not HTTP 500. This informs the client it is a configuration error on their side, not a server error.