### PR TITLE
Add ignore for event bad token key requests

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -9,7 +9,8 @@ function shouldSendToSentry(error: Error): boolean {
 	if (
 		error instanceof PageNotFoundError ||
 		error instanceof MethodNotAllowedError ||
-		error instanceof HeaderNotDefinedError
+		error instanceof HeaderNotDefinedError ||
+		error instanceof BadTokenKeyRequestedError
 	) {
 		return false;
 	}


### PR DESCRIPTION
Bad token key request don't have to be sent to sentry. This creates noise. They are recorded via metrics.

Relates to the change in #51 