### PR TITLE
Fix not-before time to be in seconds

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ export const handleTokenDirectory = async (ctx: Context, request: Request) => {
 		'token-keys': keys.objects.map(key => ({
 			'token-type': TokenType.BlindRSA,
 			'token-key': (key.customMetadata as StorageMetadata).publicKey,
-			'not-before': new Date(key.uploaded).getTime(),
+			'not-before': new Date(key.uploaded).getTime() / 1000, // the spec mandates to use seconds
 		})),
 	};
 


### PR DESCRIPTION
not-before should be in seconds instead of milliseconds, per the [spec](https://datatracker.ietf.org/doc/rfc9578/).