### PR TITLE
Fix not-before to be an integer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ export const handleTokenDirectory = async (ctx: Context, request: Request) => {
 		'token-keys': keys.objects.map(key => ({
 			'token-type': TokenType.BlindRSA,
 			'token-key': (key.customMetadata as StorageMetadata).publicKey,
-			'not-before': new Date(key.uploaded).getTime() / 1000, // the spec mandates to use seconds
+			'not-before': Math.trunc(new Date(key.uploaded).getTime() / 1000), // the spec mandates to use seconds
 		})),
 	};
 


### PR DESCRIPTION
Dividing by 1000 in javascript can create a float. The spec asks for 64-bit integer.

This commit updates not-before to truncate it, ensuring it's always an integer.
In addition, it adds a regression test.