### PR TITLE
Add stale while revalidate behaviour cache

### DIFF
--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -21,10 +21,10 @@ export class Context {
 		public logger: Logger,
 		public metrics: MetricsRegistry
 	) {
-		const cache = new CascadingCache(new InMemoryCache(), new APICache('r2/issuance_keys'));
-		const cachedR2Bucket = new CachedR2Bucket(this, env.ISSUANCE_KEYS, cache);
 		// eslint-disable-next-line @typescript-eslint/no-this-alias
 		const ctx = this;
+		const cache = new CascadingCache(new InMemoryCache(ctx), new APICache(ctx, 'r2/issuance_keys'));
+		const cachedR2Bucket = new CachedR2Bucket(ctx, env.ISSUANCE_KEYS, cache);
 
 		const cachedR2BucketWithRetries = new Proxy(cachedR2Bucket, {
 			get: (target, prop, receiver) => {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,0 +1,28 @@
+import { shouldRevalidate, STALE_WHILE_REVALIDATE_IN_MS } from '../src/cache';
+
+describe('cache revalidation', () => {
+	it('should not revalidate before expiration', () => {
+		const expiration = new Date(Date.now());
+		expect(shouldRevalidate(expiration)).toBe(false);
+	});
+
+	it('should revalidate when after expiration and staleness', () => {
+		const expiration = new Date(Date.now() - STALE_WHILE_REVALIDATE_IN_MS);
+		expect(shouldRevalidate(expiration)).toBe(true);
+	});
+
+	it('should not always revalidate when after expiration but still within staleness interval', () => {
+		const expiration = new Date(Date.now() - STALE_WHILE_REVALIDATE_IN_MS / 2);
+		let hasSeenFalse = false;
+		let hasSeenTrue = false;
+		for (let i = 0; i < 1_000_000; i += 1) {
+			if (shouldRevalidate(expiration)) {
+				hasSeenTrue = true;
+			} else {
+				hasSeenFalse = true;
+			}
+		}
+		expect(hasSeenFalse).toBe(true);
+		expect(hasSeenTrue).toBe(true);
+	});
+});


### PR DESCRIPTION
Add the behaviour to both InMemoryCache and APICache.

This allows to provide a reply to the client without waiting on the origin storage.