### PR TITLE
Split cache by hostname

### DIFF
--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -10,12 +10,14 @@ import { MetricsRegistry } from './metrics';
 export type WaitUntilFunc = (p: Promise<unknown>) => void;
 
 export class Context {
+	public hostname: string;
 	public startTime: number;
 	private promises: Promise<unknown>[] = [];
 	public bucket: { ISSUANCE_KEYS: CachedR2Bucket };
 	public performance: Performance;
 
 	constructor(
+		request: Request,
 		public env: Bindings,
 		private _waitUntil: WaitUntilFunc,
 		public logger: Logger,
@@ -39,6 +41,7 @@ export class Context {
 			},
 		});
 
+		this.hostname = new URL(request.url).hostname;
 		this.bucket = {
 			ISSUANCE_KEYS: cachedR2BucketWithRetries,
 		};

--- a/src/router.ts
+++ b/src/router.ts
@@ -120,7 +120,7 @@ export class Router {
 				coloName: request?.cf?.colo as string,
 			});
 		}
-		return new Context(env, ectx.waitUntil.bind(ectx), logger, metrics);
+		return new Context(request, env, ectx.waitUntil.bind(ectx), logger, metrics);
 	}
 
 	private async postProcessing(ctx: Context) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -51,7 +51,11 @@ describe('challenge handlers', () => {
 	};
 
 	it('should return a Privacy Pass token response when provided with a valid Privacy Pass token request', async () => {
-		const ctx = getContext({ env: getEnv(), ectx: new ExecutionContextMock() });
+		const ctx = getContext({
+			request: new Request(sampleURL),
+			env: getEnv(),
+			ectx: new ExecutionContextMock(),
+		});
 
 		const msgString = 'Hello World!';
 		const message = new TextEncoder().encode(msgString);
@@ -254,7 +258,11 @@ describe('directory', () => {
 
 describe('key rotation', () => {
 	it('should rotate key at every minute', async () => {
-		const ctx = getContext({ env: getEnv(), ectx: new ExecutionContextMock() });
+		const ctx = getContext({
+			request: new Request(sampleURL),
+			env: getEnv(),
+			ectx: new ExecutionContextMock(),
+		});
 		ctx.env.ROTATION_CRON_STRING = '* * * * *'; // Every minute
 
 		const date = new Date('2023-08-01T00:01:00Z');
@@ -262,7 +270,11 @@ describe('key rotation', () => {
 	});
 
 	it('should rotate key at midnight on the first day of every month', async () => {
-		const ctx = getContext({ env: getEnv(), ectx: new ExecutionContextMock() });
+		const ctx = getContext({
+			request: new Request(sampleURL),
+			env: getEnv(),
+			ectx: new ExecutionContextMock(),
+		});
 		ctx.env.ROTATION_CRON_STRING = '0 0 1 * *'; // At 00:00 on day-of-month 1
 
 		const date = new Date('2023-09-01T00:00:00Z');
@@ -270,7 +282,11 @@ describe('key rotation', () => {
 	});
 
 	it('should rotate key at 12:30 PM every day', async () => {
-		const ctx = getContext({ env: getEnv(), ectx: new ExecutionContextMock() });
+		const ctx = getContext({
+			request: new Request(sampleURL),
+			env: getEnv(),
+			ectx: new ExecutionContextMock(),
+		});
 		ctx.env.ROTATION_CRON_STRING = '30 12 * * *'; // At 12:30 every day
 
 		const date = new Date('2023-08-01T12:30:00Z');
@@ -278,7 +294,11 @@ describe('key rotation', () => {
 	});
 
 	it('should not rotate key at noon on a non-rotation day', async () => {
-		const ctx = getContext({ env: getEnv(), ectx: new ExecutionContextMock() });
+		const ctx = getContext({
+			request: new Request(sampleURL),
+			env: getEnv(),
+			ectx: new ExecutionContextMock(),
+		});
 		ctx.env.ROTATION_CRON_STRING = '0 0 1 * *'; // At 00:00 on day-of-month 1
 
 		const date = new Date('2023-08-02T12:00:00Z'); // 2nd August is not the 1st
@@ -286,7 +306,11 @@ describe('key rotation', () => {
 	});
 
 	it('should rotate key at 11:59 PM on the last day of the month', async () => {
-		const ctx = getContext({ env: getEnv(), ectx: new ExecutionContextMock() });
+		const ctx = getContext({
+			request: new Request(sampleURL),
+			env: getEnv(),
+			ectx: new ExecutionContextMock(),
+		});
 		ctx.env.ROTATION_CRON_STRING = '59 23 * * *'; // At 23:59 on the last day of the month
 
 		const date = new Date('2023-08-31T23:59:00Z'); // 31st August 2023 is the last day of the month
@@ -294,7 +318,11 @@ describe('key rotation', () => {
 	});
 
 	it('should handle rotation with millisecond precision', async () => {
-		const ctx = getContext({ env: getEnv(), ectx: new ExecutionContextMock() });
+		const ctx = getContext({
+			request: new Request(sampleURL),
+			env: getEnv(),
+			ectx: new ExecutionContextMock(),
+		});
 		ctx.env.ROTATION_CRON_STRING = '* * * * *';
 
 		const date = new Date('2023-08-01T00:01:00.010Z');

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -49,6 +49,7 @@ export class ExecutionContextMock implements ExecutionContext {
 export const getEnv = (): Bindings => getMiniflareBindings();
 
 export interface MockContextOptions {
+	request: Request;
 	env: Bindings;
 	ectx: ExecutionContext;
 	logger?: Logger;
@@ -60,5 +61,5 @@ export const getContext = (options: MockContextOptions): Context => {
 	const logger = options.logger ?? new ConsoleLogger();
 	const metrics = options.metrics ?? new MetricsRegistry(options.env, {});
 	const waitUntilFunc = options.waitUntilFunc || options.ectx.waitUntil.bind(options.ectx);
-	return new Context(options.env, waitUntilFunc, logger, metrics);
+	return new Context(options.request, options.env, waitUntilFunc, logger, metrics);
 };

--- a/test/promises.test.ts
+++ b/test/promises.test.ts
@@ -25,7 +25,11 @@ describe('asyncRetries', () => {
 	}
 
 	it('should work for a promise always resolving', async () => {
-		const ctx = getContext({ env: getEnv(), ectx: new ExecutionContextMock() });
+		const ctx = getContext({
+			request: new Request('http://localhost'),
+			env: getEnv(),
+			ectx: new ExecutionContextMock(),
+		});
 
 		const f = jest.fn(() => Promise.resolve(sampleResolve));
 		const retriesF = asyncRetries(ctx, f);
@@ -35,7 +39,11 @@ describe('asyncRetries', () => {
 	});
 
 	it('should work for a promise failing once', async () => {
-		const ctx = getContext({ env: getEnv(), ectx: new ExecutionContextMock() });
+		const ctx = getContext({
+			request: new Request('http://localhost'),
+			env: getEnv(),
+			ectx: new ExecutionContextMock(),
+		});
 
 		const f = jest.fn(generateRejectsBeforeResolvePromise(1, sampleResolve, sampleReject));
 		const retriesF = asyncRetries(ctx, f);
@@ -46,7 +54,11 @@ describe('asyncRetries', () => {
 
 	it('should reject for a promise failing twice and retry count at 2', async () => {
 		const retryCount = DEFAULT_RETRIES;
-		const ctx = getContext({ env: getEnv(), ectx: new ExecutionContextMock() });
+		const ctx = getContext({
+			request: new Request('http://localhost'),
+			env: getEnv(),
+			ectx: new ExecutionContextMock(),
+		});
 
 		const f = jest.fn(generateRejectsBeforeResolvePromise(retryCount, sampleResolve, sampleReject));
 		const retriesF = asyncRetries(ctx, f, retryCount);
@@ -61,7 +73,11 @@ describe('asyncRetries', () => {
 
 	it('should work for a promise failing twice and retry count at 3', async () => {
 		const retryCount = 3;
-		const ctx = getContext({ env: getEnv(), ectx: new ExecutionContextMock() });
+		const ctx = getContext({
+			request: new Request('http://localhost'),
+			env: getEnv(),
+			ectx: new ExecutionContextMock(),
+		});
 
 		const f = jest.fn(
 			generateRejectsBeforeResolvePromise(retryCount - 1, sampleResolve, sampleReject)
@@ -73,7 +89,11 @@ describe('asyncRetries', () => {
 	});
 
 	it('should reject a promise always failing', async () => {
-		const ctx = getContext({ env: getEnv(), ectx: new ExecutionContextMock() });
+		const ctx = getContext({
+			request: new Request('http://localhost'),
+			env: getEnv(),
+			ectx: new ExecutionContextMock(),
+		});
 
 		const f = jest.fn(() => Promise.reject(sampleReject));
 		const retriesF = asyncRetries(ctx, f);


### PR DESCRIPTION
When two issuers are run on the same zone, their cache are shared while they could have different view. This fixes it.