### PR TITLE
Fix ordering of key as they SHOULD be on the preference order

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -177,6 +177,33 @@ describe('directory', () => {
 		await initializeKeys();
 	});
 
+	it('should be ordered by latest not-before first', async () => {
+		const directoryRequest = new Request(directoryURL);
+
+		const NUMBER_OF_KEYS_GENERATED = 32; // arbitrary number, but good enough to confirm the ordering is working
+		await initializeKeys(NUMBER_OF_KEYS_GENERATED);
+
+		const response = await workerObject.fetch(
+			directoryRequest,
+			getEnv(),
+			new ExecutionContextMock()
+		);
+		expect(response.ok).toBe(true);
+
+		const directory = (await response.json()) as IssuerConfig;
+
+		let previousDate = Date.now();
+		for (const tokenKey of directory['token-keys']) {
+			if (!tokenKey['not-before']) {
+				continue;
+			}
+			const notBeforeDate = tokenKey['not-before'] * 1000;
+			expect(notBeforeDate).toBeLessThanOrEqual(previousDate);
+
+			previousDate = notBeforeDate;
+		}
+	}, 10_000);
+
 	it('response should be cached', async () => {
 		const mockCaches: Map<string, MockCache> = new Map();
 		const spy = jest.spyOn(caches, 'open').mockImplementation(async (name: string) => {


### PR DESCRIPTION
[RFC 9578](https://datatracker.ietf.org/doc/html/rfc9578#name-configuration) states that

`Clients SHOULD use the first key in the "token-keys" list that either does not have a "not-before" value or has a "not-before" value in the past, since the first such key is the most likely to be valid in the given time window.`

While it does not mentions the Issuer clearly, it is assumed the order in which the issuer returns the key is not random. We therefore order the keys by not-before.

This commit adds this behaviour, as well as a regression test.