### PR TITLE
Update clear key logic 

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -136,3 +136,10 @@ export class BadTokenKeyRequestedError extends HTTPError {
 		this.code = BadTokenKeyRequestedError.CODE;
 	}
 }
+
+export class PrevRotationTimeError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'PrevRotationTimeError';
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,10 +248,6 @@ const handleClearKey = async (ctx: Context, _request?: Request) => {
 
 	const effectivePrevRotationTime = getPrevRotationTime(new Date(latestKey.uploaded), ctx);
 
-	if (effectivePrevRotationTime == null) {
-		return new Response('Failed to determine previous rotation time', { status: 500 });
-	}
-
 	const toDelete: Set<string> = new Set();
 
 	for (const key of keys.objects) {

--- a/src/utils/keyRotation.ts
+++ b/src/utils/keyRotation.ts
@@ -1,17 +1,45 @@
 import { Bindings } from '../bindings';
 import cronParser from 'cron-parser';
+import { Context } from '../context';
+import { PrevRotationTimeError } from '../errors';
+
+interface CronParseResult {
+	prevTime?: number;
+	nextTime?: number;
+	match: boolean;
+}
+
+const KEY_LIFESPAN = 48 * 60 * 60 * 1000;
+
+export function getPrevRotationTime(mostRecentKeyUploadTime: Date, ctx: Context): number {
+	let effectivePrevTime: number;
+	if (ctx.env.ROTATION_CRON_STRING) {
+		const { prevTime } = matchCronTime(ctx.env.ROTATION_CRON_STRING, mostRecentKeyUploadTime);
+
+		if (prevTime === undefined) {
+			console.error('Failed to determine previous rotation time for key');
+			throw new PrevRotationTimeError('Failed to determine previous rotation time');
+		}
+
+		effectivePrevTime = Math.max(prevTime, mostRecentKeyUploadTime.getTime());
+	} else {
+		effectivePrevTime = mostRecentKeyUploadTime.getTime();
+	}
+	return effectivePrevTime;
+}
 
 export function shouldRotateKey(date: Date, env: Bindings): boolean {
 	const utcDate = new Date(date.toISOString());
-
-	if (env.ROTATION_CRON_STRING) {
-		const result = matchCronTime(env.ROTATION_CRON_STRING, utcDate);
-		return result;
-	}
-	return false;
+	return env.ROTATION_CRON_STRING ? matchCronTime(env.ROTATION_CRON_STRING, utcDate).match : false;
 }
 
-function matchCronTime(cronString: string, date: Date): boolean {
+export function shouldClearKey(keyUploadTime: Date, now: Date, effectivePrevTime: number): boolean {
+	const keyExpirationTime = keyUploadTime.getTime() + KEY_LIFESPAN;
+	const rotationBasedExpirationTime = effectivePrevTime + KEY_LIFESPAN;
+	return now.getTime() >= Math.max(keyExpirationTime, rotationBasedExpirationTime);
+}
+
+export function matchCronTime(cronString: string, date: Date): CronParseResult {
 	// Set seconds and milliseconds to 0 to truncate to the nearest minute
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCSeconds#parameters
 	date.setUTCSeconds(0, 0);
@@ -25,12 +53,18 @@ function matchCronTime(cronString: string, date: Date): boolean {
 	try {
 		interval = cronParser.parseExpression(cronString, options);
 	} catch (error) {
-		return false;
+		console.error('Error parsing cron string', error);
+		return { match: false };
 	}
 
 	const prevDate = interval.prev().toDate();
 	const nextDate = interval.next().toDate();
 
 	const result = date.getTime() === prevDate.getTime() || date.getTime() === nextDate.getTime();
-	return result;
+
+	return {
+		prevTime: prevDate.getTime(),
+		nextTime: nextDate.getTime(),
+		match: result,
+	};
 }

--- a/src/utils/keyRotation.ts
+++ b/src/utils/keyRotation.ts
@@ -9,7 +9,7 @@ interface CronParseResult {
 	match: boolean;
 }
 
-const KEY_LIFESPAN = 48 * 60 * 60 * 1000;
+const KEY_LIFESPAN_IN_MS = 48 * 60 * 60 * 1000;
 
 export function getPrevRotationTime(mostRecentKeyUploadTime: Date, ctx: Context): number {
 	let effectivePrevTime: number;
@@ -34,8 +34,8 @@ export function shouldRotateKey(date: Date, env: Bindings): boolean {
 }
 
 export function shouldClearKey(keyUploadTime: Date, now: Date, effectivePrevTime: number): boolean {
-	const keyExpirationTime = keyUploadTime.getTime() + KEY_LIFESPAN;
-	const rotationBasedExpirationTime = effectivePrevTime + KEY_LIFESPAN;
+	const keyExpirationTime = keyUploadTime.getTime() + KEY_LIFESPAN_IN_MS;
+	const rotationBasedExpirationTime = effectivePrevTime + KEY_LIFESPAN_IN_MS;
 	return now.getTime() >= Math.max(keyExpirationTime, rotationBasedExpirationTime);
 }
 


### PR DESCRIPTION
Update clear key logic, delete keys after prevRotationDate + KEY_LIFE…SPAN (48H), except last uploaded key. This creates a 48h grace period for old keys after a key has being rotated