### PR TITLE
Fix token issuance log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ export const handleTokenRequest = async (ctx: Context, request: Request) => {
 	const signedToken = await issuer.issue(tokenRequest);
 	ctx.metrics.signedTokenTotal.inc({ key_id: keyID });
 
-	console.log(`Token issued successfully for key ${keyID}`);
+	console.debug(`Token issued successfully for key ${keyID}`);
 
 	return new Response(signedToken.serialize(), {
 		headers: { 'content-type': MediaType.PRIVATE_TOKEN_RESPONSE },


### PR DESCRIPTION
Move from console.log to console.debug, which is a better match for the level of granularity we are looking for