### PR TITLE
Remove non-standard token directory path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -307,7 +307,6 @@ export default {
 
 		router
 			.get(PRIVATE_TOKEN_ISSUER_DIRECTORY, handleTokenDirectory)
-			.get('/.well-known/token-issuer-directory', handleTokenDirectory)
 			.post('/token-request', handleTokenRequest)
 			.post('/admin/rotate', handleRotateKey)
 			.post('/admin/clear', handleClearKey);


### PR DESCRIPTION
[RFC 9578, Section 8.1](https://datatracker.ietf.org/doc/html/rfc9578#name-well-known-private-token-is) registers `/.well-known/private-token-issuer-directory` as the only well-known to serve Privacy Pass Issuer directory. This commit removes non-standard endpoint that were placed under `/.well-known` for backward compatibility of certain client implementations.