### PR TITLE
Add configurable not-before delay

### DIFF
--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -25,6 +25,7 @@ export interface Bindings {
 	// Key rotation schedule
 	ROTATION_CRON_STRING?: string;
 	KEY_LIFESPAN_IN_MS: string;
+	KEY_NOT_BEFORE_DELAY_IN_MS: string;
 	MINIMUM_FRESHEST_KEYS: string;
 
 	// telemetry

--- a/src/utils/keyRotation.ts
+++ b/src/utils/keyRotation.ts
@@ -12,8 +12,8 @@ export function shouldRotateKey(date: Date, env: Bindings): boolean {
 	return env.ROTATION_CRON_STRING ? matchCronTime(env.ROTATION_CRON_STRING, utcDate).match : false;
 }
 
-export function shouldClearKey(keyUploadTime: Date, lifespanInMs: number): boolean {
-	const keyExpirationTime = keyUploadTime.getTime() + lifespanInMs;
+export function shouldClearKey(keyNotBefore: Date, lifespanInMs: number): boolean {
+	const keyExpirationTime = keyNotBefore.getTime() + lifespanInMs;
 	return Date.now() > keyExpirationTime;
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -203,7 +203,7 @@ describe('directory', () => {
 
 		const directory = (await response.json()) as IssuerConfig;
 
-		let previousDate = Date.now();
+		let previousDate = Date.now() + Number.parseInt(env.KEY_NOT_BEFORE_DELAY_IN_MS);
 		for (const tokenKey of directory['token-keys']) {
 			if (!tokenKey['not-before']) {
 				continue;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,6 +17,7 @@ crons = ["0 0 * * *"]
 DIRECTORY_CACHE_MAX_AGE_SECONDS = "86400"
 ENVIRONMENT = "production"
 KEY_LIFESPAN_IN_MS = "172800000" # 48h
+KEY_NOT_BEFORE_DELAY_IN_MS = "7200000" # 2h
 MINIMUM_FRESHEST_KEYS = "1"
 ROTATION_CRON_STRING = "30 12 * * *"
 SENTRY_SAMPLE_RATE = "0" # Between 0-1 if you log errors on Sentry. 0 disables Sentry logging. Configuration is done through Workers Secrets


### PR DESCRIPTION
This commit adds `KEY_NOT_BEFORE_DELAY_IN_MS` binding. This is the delay that is going to be added when generating key to their `notBefore` parameter. This allow a key to be generated at time `t` to not be valid before `t+KEY_NOT_BEFORE_DELAY_IN_MS`.

Key rotation and tests are updated accordingly.
This is backward compatible with deployed codebase, defaulting to `KEY_NOT_BEFORE_DELAY_IN_MS=0` which was the previous behaviour.