### PR TITLE
Make RPC request agnostic

### DIFF
--- a/dist/types/index.d.ts
+++ b/dist/types/index.d.ts
@@ -203,8 +203,8 @@ export declare class IssuerHandler extends WorkerEntrypoint<Bindings> {
 		status?: number;
 		responseContentType: string;
 	}>;
-	rotateKey(url: string, prefix: string): Promise<Response>;
-	clearKey(url: string, prefix: string): Promise<Response>;
+	rotateKey(url: string, prefix: string): Promise<Uint8Array>;
+	clearKey(url: string, prefix: string): Promise<string[]>;
 }
 declare const _default: {
 	fetch(request: Request, env: Bindings, ctx: ExecutionContext): Promise<Response>;


### PR DESCRIPTION
Having to receive complex types like `Response` over rpc causes a few issues with stubs and overall I believe makes for a worse API. So I propose these two methods be changed.

The `tokenDirectory` method I left untouched as that requires handling of the cache and the entire request is cached currently. 