### PR TITLE
Replace cron parsing with simpler string comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
 				"@cloudflare/privacypass-ts": "0.7.1",
 				"@sentry/cli": "2.26.0",
 				"@sentry/types": "7.95.0",
-				"cron-parser": "4.9.0",
 				"promjs-plus": "0.5.4",
 				"toucan-js": "3.3.1",
 				"typescript": "5.3.3"
@@ -3193,18 +3192,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/cron-parser": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
-			"integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
-			"license": "MIT",
-			"dependencies": {
-				"luxon": "^3.2.1"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4288,15 +4275,6 @@
 			"integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/luxon": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
-			"integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			}
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.17",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
 		"@cloudflare/privacypass-ts": "0.7.1",
 		"@sentry/cli": "2.26.0",
 		"@sentry/types": "7.95.0",
-		"cron-parser": "4.9.0",
 		"promjs-plus": "0.5.4",
 		"toucan-js": "3.3.1",
 		"typescript": "5.3.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,6 @@ import {
 } from './cache';
 const { BlindRSAMode, Issuer, TokenRequest } = publicVerif;
 const { BatchedTokenRequest, BatchedTokenResponse, Issuer: BatchedTokensIssuer } = arbitraryBatched;
-import { shouldRotateKey } from './utils/keyRotation';
 
 import { shouldClearKey } from './utils/keyRotation';
 import { WorkerEntrypoint } from 'cloudflare:workers';
@@ -563,10 +562,9 @@ export default {
 
 		const checkedEnv = checkMandatoryBindings(env);
 		const context = Router.buildContext(sampleRequest, checkedEnv, ctx);
-		const date = new Date(event.scheduledTime);
 
 		try {
-			if (shouldRotateKey(date, checkedEnv)) {
+			if (event.cron === checkedEnv.ROTATION_CRON_STRING) {
 				await handleRotateKey(context, sampleRequest);
 			} else {
 				await handleClearKey(context, sampleRequest);

--- a/src/utils/keyRotation.ts
+++ b/src/utils/keyRotation.ts
@@ -1,48 +1,4 @@
-import { Bindings } from '../bindings';
-import cronParser from 'cron-parser';
-
-interface CronParseResult {
-	prevTime?: number;
-	nextTime?: number;
-	match: boolean;
-}
-
-export function shouldRotateKey(date: Date, env: Bindings): boolean {
-	const utcDate = new Date(date.toISOString());
-	return env.ROTATION_CRON_STRING ? matchCronTime(env.ROTATION_CRON_STRING, utcDate).match : false;
-}
-
 export function shouldClearKey(keyNotBefore: Date, lifespanInMs: number): boolean {
 	const keyExpirationTime = keyNotBefore.getTime() + lifespanInMs;
 	return Date.now() > keyExpirationTime;
-}
-
-export function matchCronTime(cronString: string, date: Date): CronParseResult {
-	// Set seconds and milliseconds to 0 to truncate to the nearest minute
-	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCSeconds#parameters
-	date.setUTCSeconds(0, 0);
-
-	const options = {
-		currentDate: date.toISOString(),
-		tz: 'UTC',
-	};
-
-	let interval;
-	try {
-		interval = cronParser.parseExpression(cronString, options);
-	} catch (error) {
-		console.error('Error parsing cron string', error);
-		return { match: false };
-	}
-
-	const prevDate = interval.prev().toDate();
-	const nextDate = interval.next().toDate();
-
-	const result = date.getTime() === prevDate.getTime() || date.getTime() === nextDate.getTime();
-
-	return {
-		prevTime: prevDate.getTime(),
-		nextTime: nextDate.getTime(),
-		match: result,
-	};
 }


### PR DESCRIPTION
We don't have to implement cron parsing inside the worker to determine
if it needs to rotate or clear keys. We can just compare `event.cron` to
the configured cron string
